### PR TITLE
Add concentration parameters of air pollutants.

### DIFF
--- a/include/NFmiParameterName.h
+++ b/include/NFmiParameterName.h
@@ -1462,6 +1462,14 @@ enum FmiParameterName
   kFmiIcingRate = 4820,
   kFmiIceMass = 4821,
 
+  kFmiCOConcentration = 4900,
+  kFmiNOConcentration,
+  kFmiNO2Concentration,
+  kFmiO3Concentration,
+  kFmiPM10Concentration,
+  kFmiPM25Concentration,
+  kFmiSO2Concentration,
+
   // Some value larger than any other enum value
   kFmiLastParameter = 6000
 

--- a/source/NFmiEnumConverter.cpp
+++ b/source/NFmiEnumConverter.cpp
@@ -1450,6 +1450,13 @@ static void InitParamNames(NFmiEnumConverter::storage_type &theData)
   PARAMINSERT("VolumetricSoilWaterLayer4", kFmiVolumetricSoilWaterLayer4);
   PARAMINSERT("HighVegetationType", kFmiHighVegetationType);
   PARAMINSERT("LowVegetationType", kFmiLowVegetationType);
+  PARAMINSERT("COConcentration", kFmiCOConcentration);
+  PARAMINSERT("NOConcentration", kFmiNOConcentration);
+  PARAMINSERT("NO2Concentration", kFmiNO2Concentration);
+  PARAMINSERT("O3Concentration", kFmiO3Concentration);
+  PARAMINSERT("PM10Concentration", kFmiPM10Concentration);
+  PARAMINSERT("PM25Concentration", kFmiPM25Concentration);
+  PARAMINSERT("SO2Concentration", kFmiSO2Concentration);
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
At the moment there is not available any concentration parameters
of air pollutants in the library. These additions makes possible to
store mass per unit volume forecast data of air pollutants.

Naming of a parameter does not take account which is the unit of data
but it must be an unit of concentration. Unit can be for example
milligrams of pollutant per cubic meter.

There is not any instructions how the parameters should be named in the project. Hopefully, the selected names are fine.