### PR TITLE
Added possibility to memory map a new writeable querydata file

### DIFF
--- a/include/NFmiQueryData.h
+++ b/include/NFmiQueryData.h
@@ -40,6 +40,7 @@ class _FMI_DLL NFmiQueryData
   // methods
   bool Init(const NFmiQueryInfo &theInfo);
   bool Init();
+  bool Init(const std::string &theHeader, const std::string &theFilename, bool fInitialize);
   void Destroy();
 
   NFmiQueryInfo *Info() const;

--- a/include/NFmiQueryDataUtil.h
+++ b/include/NFmiQueryDataUtil.h
@@ -136,7 +136,7 @@ class MyGrid
 
 struct CombinedParamStruct
 {  // t‰m‰ structi piti tehd‰, ett‰ sain v‰hennetty‰ boost::in Thread:ille annettujen parametrin
-   // m‰‰r‰‰ (max 9 parametria)
+  // m‰‰r‰‰ (max 9 parametria)
   CombinedParamStruct(void)
       : weather1(false), weather2(false), wind1(false), wind2(false), wind3(false)
   {
@@ -452,6 +452,9 @@ class _FMI_DLL NFmiQueryDataUtil
                                           bool fForceTimeBag = false);
 
   static NFmiQueryData *CreateEmptyData(NFmiQueryInfo &srcInfo);
+  static NFmiQueryData *CreateEmptyData(NFmiQueryInfo &srcInfo,
+                                        const std::string &theFilename,
+                                        bool fInitialize);
 
   //@{ \name datan konversiot 6:sta 7:aan tai p‰invastoin -funktiot
   static NFmiQueryData *FqdV6ToV7(NFmiFastQueryInfo &theSourceInfo);

--- a/include/NFmiRawData.h
+++ b/include/NFmiRawData.h
@@ -26,6 +26,10 @@ class _FMI_DLL NFmiRawData
 
   NFmiRawData();
   bool Init(size_t size);
+  bool Init(size_t size,
+            const std::string& theHeader,
+            const std::string& theFilename,
+            bool fInitialize);
 
   NFmiRawData(const NFmiRawData& other);
 

--- a/smartmet-library-newbase.spec
+++ b/smartmet-library-newbase.spec
@@ -62,6 +62,9 @@ FMI newbase development files
 %{_includedir}/smartmet/%{DIRNAME}
 
 %changelog
+* Upcoming
+- Added possibility to memory map writeable querydata
+
 * Thu Jan 26 2017 Mika Heiskanen <mika.heiskanen@fmi.fi> - 17.1.26-1.fmi
 - Added methods for calculating a hash value for the grid defined in querydata
 

--- a/source/NFmiQueryData.cpp
+++ b/source/NFmiQueryData.cpp
@@ -345,6 +345,21 @@ bool NFmiQueryData::Init(const NFmiQueryInfo &theInfo)
 
 // ----------------------------------------------------------------------
 /*!
+ * \brief Initialize memory mapped querydata
+ */
+// ----------------------------------------------------------------------
+
+bool NFmiQueryData::Init(const std::string &theHeader,
+                         const std::string &theFilename,
+                         bool fInitialize)
+{
+  if (!itsQueryInfo) return false;
+
+  return itsRawData->Init(itsQueryInfo->Size(), theHeader, theFilename, fInitialize);
+}
+
+// ----------------------------------------------------------------------
+/*!
  * \return Undocumented
  * \todo Should return an boost::shared_ptr
  */

--- a/source/NFmiQueryDataUtil.cpp
+++ b/source/NFmiQueryDataUtil.cpp
@@ -536,6 +536,32 @@ NFmiQueryData *NFmiQueryDataUtil::CreateEmptyData(NFmiQueryInfo &srcInfo)
 
 // ----------------------------------------------------------------------
 /*!
+ * \brief Create a memory mapped querydata for writing
+ *
+ * \param srcInfo Header data
+ * \param theFilename Filename for the mmapped data
+ * \param fInitialize True, if data is to be initialized to missing values
+ */
+// ----------------------------------------------------------------------
+
+NFmiQueryData *NFmiQueryDataUtil::CreateEmptyData(NFmiQueryInfo &srcInfo,
+                                                  const std::string &theFilename,
+                                                  bool fInitialize)
+{
+  if (srcInfo.Size() == 0)
+    throw std::runtime_error("Attempt to create empty querydata as a memory mapped file");
+  NFmiQueryData *data = new NFmiQueryData(srcInfo);
+
+  std::ostringstream header;
+  header << srcInfo;
+
+  // Initialize with given info as a string to given filename
+  data->Init(header.str(), theFilename, fInitialize);
+  return data;
+}
+
+// ----------------------------------------------------------------------
+/*!
  * Luo uuden QDatan, jossa on vain halutut parametrit. Voidaan käyttää
  * myös irroittamaan yhdistelmä parametrien aliparametreja.
  *


### PR DESCRIPTION
Sample code:
```cpp
int main()
{
  // Memory map a sample input file
  NFmiQueryData qd("input.sqd");
  NFmiFastQueryInfo src(&qd);

  // Make a copy with all data points set to a missing value
  NFmiQueryData* out1 = NFmiQueryDataUtil::CreateEmptyData(src, "missing.sqd", true);

  // Make a copy with all data points zeroed out
  NFmiQueryData* out2 = NFmiQueryDataUtil::CreateEmptyData(src, "zeros.sqd", false);

  // Make a copy of the original
  NFmiQueryData* out3 = NFmiQueryDataUtil::CreateEmptyData(src, "copy.sqd", false);
  NFmiFastQueryInfo dst(out3);
  for (src.ResetParam(), dst.ResetParam(); src.NextParam() && dst.NextParam();)
    for (src.ResetLocation(), dst.ResetLocation(); src.NextLocation() && dst.NextLocation();)
      for (src.ResetLevel(), dst.ResetLevel(); src.NextLevel() && dst.NextLevel();)
        for (src.ResetTime(), dst.ResetTime(); src.NextTime() && dst.NextTime();)
          dst.FloatValue(src.FloatValue());

  delete out1;
  delete out2;
  delete out3;

  return 0;
}
```