### PR TITLE
Ignore use of NFmiGdalArea in NFmiArea if not UNIX

### DIFF
--- a/newbase/NFmiArea.cpp
+++ b/newbase/NFmiArea.cpp
@@ -489,8 +489,9 @@ std::size_t NFmiArea::HashValue() const
 
 std::size_t NFmiArea::HashValueKludge() const
 {
+#ifdef UNIX
   if (const auto *a = dynamic_cast<const NFmiGdalArea *>(this)) return a->HashValue();
-
+#endif
   if (const auto *a = dynamic_cast<const NFmiGnomonicArea *>(this)) return a->HashValue();
 
   if (const auto *a = dynamic_cast<const NFmiLambertEqualArea *>(this)) return a->HashValue();

--- a/smartmet-library-newbase.spec
+++ b/smartmet-library-newbase.spec
@@ -75,6 +75,9 @@ FMI newbase static library
 %{_libdir}/libsmartmet-%{DIRNAME}.a
 
 %changelog
+* Upcoming
+- Ignore use of NFmiGdalArea in NFmiArea if not UNIX
+
 * Tue Aug 1 2017 Ville Ilkka <ville.ilkka@fmi.fi> - 17.8.1-1.fmi
 - Added a new parameter for 5cm snow accumulation days
 


### PR DESCRIPTION
On Windows the library does not compile without ignoring all the use of NFmiGdalArea.