### PR TITLE
Add a possibility to disable Gdal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,12 @@ objdir = obj
 
 DEFINES = -DUNIX -D_REENTRANT -DFMI_COMPRESSION -DBOOST -DBOOST_IOSTREAMS_NO_LIB
 
+# Say 'yes' to disable Gdal
+DISABLED_GDAL=
+ifeq ($(DISABLED_GDAL),yes)
+  DEFINES += -DDISABLED_GDAL
+endif
+
 ifeq ($(CXX), clang++)
 
  FLAGS = \
@@ -76,8 +82,10 @@ CFLAGS_PROFILE = $(DEFINES) $(FLAGS) $(FLAGS_PROFILE) -DNDEBUG -O2 -g -pg
 LIBS = -L$(libdir) \
 	-lboost_filesystem \
 	-lboost_regex \
-	-lboost_thread \
-	-lgdal
+	-lboost_thread
+ifneq ($(DISABLED_GDAL),yes)
+  LIBS += -lgdal
+endif
 
 # What to install
 

--- a/newbase/NFmiArea.cpp
+++ b/newbase/NFmiArea.cpp
@@ -490,7 +490,9 @@ std::size_t NFmiArea::HashValue() const
 std::size_t NFmiArea::HashValueKludge() const
 {
 #ifdef UNIX
+#ifndef DISABLED_GDAL
   if (const auto *a = dynamic_cast<const NFmiGdalArea *>(this)) return a->HashValue();
+#endif
 #endif
   if (const auto *a = dynamic_cast<const NFmiGnomonicArea *>(this)) return a->HashValue();
 

--- a/newbase/NFmiAreaFactory.cpp
+++ b/newbase/NFmiAreaFactory.cpp
@@ -449,7 +449,17 @@ boost::shared_ptr<NFmiArea> Create(const std::string &theProjection)
       area.reset(
           new NFmiGdalArea(datum, proj, bottomleft, topright, corner1, corner2, usePacificView));
     }
+#else
+    else
+    {
+      throw std::runtime_error("gdal disabled");
+    }
 #endif  // DISABLED_GDAL
+#else
+    else
+    {
+      throw std::runtime_error("unsupported projection");
+    }
 #endif  // UNIX
 
     // recalculate corners if center coordinate was given

--- a/newbase/NFmiAreaFactory.cpp
+++ b/newbase/NFmiAreaFactory.cpp
@@ -432,6 +432,7 @@ boost::shared_ptr<NFmiArea> Create(const std::string &theProjection)
           new NFmiEquidistArea(bottomleft, topright, clon, corner1, corner2, clat, usePacificView));
     }
 #ifdef UNIX
+#ifndef DISABLED_GDAL
     else
     {
       // Allow FMI: or WGS84: prefix to identify datum, default is WGS84
@@ -448,6 +449,7 @@ boost::shared_ptr<NFmiArea> Create(const std::string &theProjection)
       area.reset(
           new NFmiGdalArea(datum, proj, bottomleft, topright, corner1, corner2, usePacificView));
     }
+#endif  // DISABLED_GDAL
 #endif  // UNIX
 
     // recalculate corners if center coordinate was given

--- a/newbase/NFmiGdalArea.cpp
+++ b/newbase/NFmiGdalArea.cpp
@@ -6,6 +6,7 @@
 // ======================================================================
 
 #ifdef UNIX
+#ifndef DISABLED_GDAL
 
 #include "NFmiGdalArea.h"
 #include "NFmiString.h"
@@ -586,6 +587,7 @@ std::size_t NFmiGdalArea::HashValue() const
   return hash;
 }
 
+#endif  // DISABLED_GDAL
 #endif  // UNIX
 
 // ======================================================================

--- a/newbase/NFmiGdalArea.h
+++ b/newbase/NFmiGdalArea.h
@@ -6,6 +6,7 @@
 // ======================================================================
 
 #ifdef UNIX
+#ifndef DISABLED_GDAL
 
 #pragma once
 
@@ -101,6 +102,7 @@ class _FMI_DLL NFmiGdalArea : public NFmiArea
 
 };  // class NFmiGdalArea
 
-#endif  // NFMIGDALAREA_H
+#endif  // DISABLED_GDAL
+#endif  // UNIX
 
 // ======================================================================

--- a/newbase/NFmiSaveBaseFactory.cpp
+++ b/newbase/NFmiSaveBaseFactory.cpp
@@ -78,8 +78,10 @@ void *CreateSaveBase(unsigned int classId)
     case kNFmiStationBag:
       return static_cast<void *>(new NFmiStationBag);
 #ifdef UNIX
+#ifndef DISABLED_GDAL
     case kNFmiGdalArea:
       return static_cast<void *>(new NFmiGdalArea);
+#endif
 #endif
 
     default:


### PR DESCRIPTION
Shared version of Gdal library links libpoppler.so which has memory leaks. If the library is used trough Java Native Access library, java program may crash because the leaks.