### PR TITLE
Add CMake option DISABLE_GDAL for linux

### DIFF
--- a/cmake/Linux.cmake
+++ b/cmake/Linux.cmake
@@ -1,4 +1,12 @@
 message(STATUS "System Name: ${CMAKE_SYSTEM_NAME}")
 message(STATUS "Install Prefix: ${CMAKE_INSTALL_PREFIX}")
+
+option(DISABLE_GDAL "Disable GDAL" OFF)
+
 set(CMAKE_CXX_FLAGS "-DUNIX -D_REENTRANT -DFMI_COMPRESSION -DBOOST -DBOOST_IOSTREAMS_NO_LIB")
+
+if(DISABLE_GDAL)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDISABLED_GDAL")
+endif()
+
 add_compile_options(-std=c++11 -fPIC -MD -Wall -W -Wno-unused-parameter)


### PR DESCRIPTION
The option is alredy available with direct build with the make utility. The change adds a possibility to compile the library without GDAL with CMake.

By default GDAL is enabled. To disable GDAL, run cmake with the -DDISABLE_GDAL=ON command line option or disable it through the CMake curses interface.