### PR TITLE
Find and link fmt library during CMake compilation on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ if(NOT TARGET uninstall)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  target_link_libraries(${PROJECT_NAME} ${Fmt_LIBRARIES})
   include(cmake/package.cmake OPTIONAL)
 endif()
 

--- a/cmake/Linux.cmake
+++ b/cmake/Linux.cmake
@@ -11,3 +11,12 @@ if(DISABLE_GDAL)
 endif()
 
 add_compile_options(-std=c++11 -fPIC -MD -Wall -W -Wno-unused-parameter)
+
+find_package(Fmt REQUIRED)
+if (Fmt_FOUND)
+  find_library(Fmt_LIBRARIES fmt ${CMAKE_INSTALL_PREFIX} PATH_SUFFIXES a so)
+  if (Fmt_LIBRARIES-NOTFOUND)
+    message(FATAL_ERROR "Fmt library not found")
+  endif()
+  message(STATUS "Fmt: ${Fmt_LIBRARIES}")
+endif()


### PR DESCRIPTION
The library compilation using CMake does work without linkin Fmt library on Linux. The changes in the branch fix the problem for shared library compilation. There is a possibility to use header only library of fmt when building static version of newbase, but I didn't get it to work on Linux.