### PR TITLE
Link boost date_time to the library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ CFLAGS_PROFILE = $(DEFINES) $(FLAGS) $(FLAGS_PROFILE) -DNDEBUG -O2 -g -pg
 
 LIBS = -L$(libdir) \
 	-lfmt \
+	-lboost_date_time \
 	-lboost_filesystem \
 	-lboost_regex \
 	-lboost_thread

--- a/smartmet-library-newbase.spec
+++ b/smartmet-library-newbase.spec
@@ -80,6 +80,9 @@ FMI newbase static library
 %{_libdir}/libsmartmet-%{DIRNAME}.a
 
 %changelog
+* Upcoming
+- Link boost date_time to the library
+
 * Wed Aug 22 2018 Mika Heiskanen <mika.heiskanen@fmi.fi> - 18.8.22-1.fmi
 - Fixed to compile on Windows
 


### PR DESCRIPTION
Boost date_time is used in the library, so better to link it aboard.